### PR TITLE
Add option for choosing dependency type to install on rosdep install

### DIFF
--- a/scripts/ros1-workspace-build.sh
+++ b/scripts/ros1-workspace-build.sh
@@ -19,7 +19,7 @@
 BUILD_MODE="${BUILD_MODE:-RELEASE}"
 # Type of dependency packages to install when using rosdep
 # Eg: ROSDEP_INSTALL_DEPENDENCY_TYPES="buildtool build_export exec doc test build buildtool_export"
-ROSDEP_INSTALL_DEPENDENCY_TYPES="${ROSDEP_INSTALL_DEPENDENCY_TYPES:-"All"}"
+ROSDEP_INSTALL_DEPENDENCY_TYPES="${ROSDEP_INSTALL_DEPENDENCY_TYPES:-"all"}"
 ROSDEP_CHECK_FAIL_MSG_FILTER_KEY="Cannot locate rosdep definition for"
 
 set -e
@@ -42,14 +42,13 @@ wstool update -t ${MOVAI_USERSPACE}/cache/ros/src
 rosdep update
 # Choose what type of dependencies to install using rosdep
 # If ROSDEP_INSTALL_DEPENDENCY_TYPES is not defined externally, install all types, else install each given type.
-if [ "$ROSDEP_INSTALL_DEPENDENCY_TYPES" = "All" ]; then
+if [ "$ROSDEP_INSTALL_DEPENDENCY_TYPES" = "all" ]; then
   printf "ROSDEP: Installing all dependency types.\n"
   rosdep install --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} -y
 else
   # Check if all dependencies are available using rosdep check.
-  MESSAGE=$(rosdep check --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} 2>&1)
-  RESULT=$(echo $MESSAGE | grep -cim1 "$ROSDEP_CHECK_FAIL_MSG_FILTER_KEY")
-  if [ $RESULT = 1 ]; then
+  MESSAGE="$(rosdep check --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} 2>&1)"
+  if [[ $MESSAGE == *"$ROSDEP_CHECK_FAIL_MSG_FILTER_KEY"* ]]; then
     printf "Atleast one of your dependencies is being failed to be resolved by rosdep.\n"
     printf "$MESSAGE.\n"
     exit 1

--- a/scripts/ros1-workspace-build.sh
+++ b/scripts/ros1-workspace-build.sh
@@ -17,6 +17,10 @@
 # File: ros1-workspace-build.sh
 
 BUILD_MODE="${BUILD_MODE:-RELEASE}"
+# Type of dependency packages to install when using rosdep
+# Eg: ROSDEP_INSTALL_DEPENDENCY_TYPES="buildtool build_export exec doc test build buildtool_export"
+ROSDEP_INSTALL_DEPENDENCY_TYPES="${ROSDEP_INSTALL_DEPENDENCY_TYPES:"All"}"
+
 set -e
 sudo apt-get update
 
@@ -35,7 +39,18 @@ printf "Updating ROS1 Workspace:\n"
 cd ${ROS1_USER_WS} >/dev/null
 wstool update -t ${MOVAI_USERSPACE}/cache/ros/src
 rosdep update
-rosdep install --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} -y
+# Choose what type of dependencies to install using rosdep
+# If ROSDEP_INSTALL_DEPENDENCY_TYPES is not defined externally, install all types, else install each given type.
+if [ "$ROSDEP_INSTALL_DEPENDENCY_TYPES" = "All" ]; then
+  printf "ROSDEP: Installing all dependency types.\n"
+  rosdep install --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} -y
+else
+  for DEPENDENCY_TYPE in $ROSDEP_INSTALL_DEPENDENCY_TYPES
+  do
+    printf "ROSDEP: Installing ${DEPENDENCY_TYPE} dependency types.\n"
+    rosdep install --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} --dependency-types=${DEPENDENCY_TYPE} -y
+  done
+fi
 
 if [ "$BUILD_MODE" = "RELEASE" ]
 then

--- a/scripts/ros1-workspace-build.sh
+++ b/scripts/ros1-workspace-build.sh
@@ -19,7 +19,7 @@
 BUILD_MODE="${BUILD_MODE:-RELEASE}"
 # Type of dependency packages to install when using rosdep
 # Eg: ROSDEP_INSTALL_DEPENDENCY_TYPES="buildtool build_export exec doc test build buildtool_export"
-ROSDEP_INSTALL_DEPENDENCY_TYPES="${ROSDEP_INSTALL_DEPENDENCY_TYPES:"All"}"
+ROSDEP_INSTALL_DEPENDENCY_TYPES="${ROSDEP_INSTALL_DEPENDENCY_TYPES:-"All"}"
 
 set -e
 sudo apt-get update
@@ -45,6 +45,8 @@ if [ "$ROSDEP_INSTALL_DEPENDENCY_TYPES" = "All" ]; then
   printf "ROSDEP: Installing all dependency types.\n"
   rosdep install --from-paths ${MOVAI_USERSPACE}/cache/ros/src --ignore-src --rosdistro ${ROS_DISTRO} -y
 else
+  # TODO: Check if all dependencies are available using rosdep check
+
   for DEPENDENCY_TYPE in $ROSDEP_INSTALL_DEPENDENCY_TYPES
   do
     printf "ROSDEP: Installing ${DEPENDENCY_TYPE} dependency types.\n"


### PR DESCRIPTION
- Add option for choosing dependency type to install on rosdep install,
- The plan is to set ROSDEP_INSTALL_DEPENDENCY_TYPES=build in the build pipeline
  - If this flag is used, the rosdep only installs the <build_depend> and <depend> flags.
- Build time reduced from 15:18 to 01:37

Current on movai_tugbot:
```
real	12m26.176s
user	0m0.270s
sys	0m0.455s
```

After the update:
```
real	1m37.553s
user	0m0.063s
sys	0m0.059s
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
