### PR TITLE
sensure no new lines on package name conversion

### DIFF
--- a/scripts/ros1-workspace-package.sh
+++ b/scripts/ros1-workspace-package.sh
@@ -122,6 +122,11 @@ function boostrap_debian_metadata_ros_pkg(){
         then
             package_name="$pkg_name-dbg"
         fi
+
+        # Ensure no new lines nor spaces from greps
+        read -r pkg_name <<<"${pkg_name//[$'\t\r\n']}"
+        read -r package_name <<<"${package_name//[$'\t\r\n']}"
+
         sed -i "s/$pkg_name/$package_name/g" ./debian/install
         sed -i "s/$pkg_name/$package_name/g" ./debian/postinst
         


### PR DESCRIPTION
Bug reported by bruno. It seems for some reason when reading the name of a ros package from package.xml it now comes with newline. Makes no sense, but now theres a further ensurance on newline cleaning.