### PR TITLE
add ppa ros-backup. Needed for ros build pipelines

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -66,6 +66,7 @@ RUN apt install curl &&\
     # movai registry
     curl -fsSL https://artifacts.cloud.mov.ai/repository/movai-applications/gpg | apt-key add - && \
     add-apt-repository "deb [arch=all] https://artifacts.cloud.mov.ai/repository/ppa-$MOVAI_PPA $MOVAI_PPA main" && \
+    add-apt-repository "deb [arch=all] https://artifacts.cloud.mov.ai/repository/ppa-proxy-ros-backup ros-backup main" && \
     apt-get update > /dev/null && \
     apt-get install git gh dh-virtualenv -y --no-install-recommends && \
     apt-get clean -y > /dev/null && \


### PR DESCRIPTION
to test simply do docker build -f noetic/Dockerfile .
Its just adding 1 ppa to the available.

To solve: https://github.com/MOV-AI/movai_ros_can_utils/actions/runs/11559000107/job/32172679774?pr=97#step:8:63