### PR TITLE
Revert "DP-1856: GPG keys expiration"

### DIFF
--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -1,6 +1,6 @@
 ARG DOCKER_REGISTRY="pubregistry.aws.cloud.mov.ai"
 ARG DOCKER_TAG=""
-FROM ${DOCKER_REGISTRY}/ce/movai-base-noetic:v2.5.1
+FROM ${DOCKER_REGISTRY}/ce/movai-base-noetic:v2.4.2
 
 # Arguments
 ARG MOVAI_ENV="develop"

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -56,6 +56,7 @@ ENV MOVAI_PPA="testing"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3008
 RUN apt install curl &&\
+    curl -fsSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros.key && \
     curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add - && \
     add-apt-repository ppa:git-core/ppa -y && \
     # gh cli registry

--- a/scripts/movai-ros-provision.sh
+++ b/scripts/movai-ros-provision.sh
@@ -13,7 +13,7 @@ source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 set -x
 
-rosdep update
+rosdep update --include-eol-distros --rosdistro=${ROS_DISTRO}
 
 printf "Preparing Mov.ai ROS packages\n"
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -44,7 +44,7 @@ done
 
 # Initialize ROS1
 source "/opt/ros/${ROS_DISTRO}/setup.bash"
-rosdep update
+rosdep update --include-eol-distros --rosdistro=${ROS_DISTRO}
 
 # Install SSH_KEYS if needed
 install_ssh_key

--- a/scripts/ros1-workspace-package.sh
+++ b/scripts/ros1-workspace-package.sh
@@ -452,7 +452,7 @@ function find_main_package_version(){
 }
 
 clear_local_apt_cache
-rosdep update --include-eol-distros
+rosdep update --include-eol-distros --rosdistro=${ROS_DISTRO}
 sudo apt-get update
 find_main_package_version
 

--- a/scripts/ros1-workspace-package.sh
+++ b/scripts/ros1-workspace-package.sh
@@ -78,7 +78,7 @@ function local_publish(){
 
     if [ $? -ne 0 ]
     then
-        rosdep update
+        rosdep update --include-eol-distros --rosdistro=${ROS_DISTRO}
     fi
 
 }
@@ -452,7 +452,7 @@ function find_main_package_version(){
 }
 
 clear_local_apt_cache
-rosdep update
+rosdep update --include-eol-distros
 sudo apt-get update
 find_main_package_version
 


### PR DESCRIPTION
- Reverts MOV-AI/containers-ros-buildtools#92
- Patches fix for ros gpg key expiration
- Adapts rosdep update to account for EOL of noetic